### PR TITLE
Enable PDF embedding via iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Files are similar:
 ![[photo.jpg | custom alt text]]
 ```
 
+PDF files referenced using image syntax will be embedded via an `<iframe>`.
+
 They explain more about the syntax in the section on [how to embed files](https://help.obsidian.md/How+to/Embed+files)
 
 

--- a/pelican/plugins/obsidian/obsidian.py
+++ b/pelican/plugins/obsidian/obsidian.py
@@ -74,9 +74,14 @@ class ObsidianMarkdownReader(YAMLMetadataReader):
             filename, linkname = get_file_and_linkname(match)
             path = FILE_PATHS.get(filename)
             if path:
-                link_structure = '![{linkname}]({{static}}{path}{filename})'.format(
-                    linkname=linkname, path=path, filename=filename
-                )
+                if filename.lower().endswith('.pdf'):
+                    link_structure = '<iframe src="{{static}}{path}{filename}"></iframe>'.format(
+                        path=path, filename=filename
+                    )
+                else:
+                    link_structure = '![{linkname}]({{static}}{path}{filename})'.format(
+                        linkname=linkname, path=path, filename=filename
+                    )
             else:
                 # don't show it at all since it will be broken
                 link_structure = ''
@@ -154,7 +159,10 @@ def populate_files_and_articles(article_generator):
     __log__.debug('Found %d articles', len(ARTICLE_PATHS))
 
     # Get list of all other relevant files
-    globs = [base_path.glob('**/*.{}'.format(ext)) for ext in ['png', 'jpg', 'jpeg', 'svg', 'apkg', 'gif', 'webp', 'avif']]
+    globs = [
+        base_path.glob('**/*.{}'.format(ext))
+        for ext in ['png', 'jpg', 'jpeg', 'svg', 'apkg', 'gif', 'webp', 'avif', 'pdf']
+    ]
     files = chain(*globs)
     for _file in files:
         full_path, filename_w_ext = os.path.split(_file)

--- a/pelican/plugins/tests/fixtures/assets/docs/sample.pdf
+++ b/pelican/plugins/tests/fixtures/assets/docs/sample.pdf
@@ -1,0 +1,7 @@
+%PDF-1.4
+1 0 obj
+<<>>
+endobj
+trailer
+<<>>
+%%EOF

--- a/pelican/plugins/tests/fixtures/internal_pdf.md
+++ b/pelican/plugins/tests/fixtures/internal_pdf.md
@@ -1,0 +1,5 @@
+---
+title: internal pdf
+---
+
+![[sample.pdf]]

--- a/pelican/plugins/tests/test_obsidian_plugin.py
+++ b/pelican/plugins/tests/test_obsidian_plugin.py
@@ -91,6 +91,13 @@ def test_internal_image_in_article(obsidian):
     assert '<p><img alt="pelican-in-rock.webp" src="{static}/assets/images/pelican-in-rock.webp"></p>' == content
 
 
+@pytest.mark.parametrize('path', ["internal_pdf"])
+def test_internal_pdf_in_article(obsidian):
+    """PDFs embedded with image syntax are rendered using iframes"""
+    content, meta = obsidian
+    assert '<iframe src="{static}/assets/docs/sample.pdf"></iframe>' == content
+
+
 @pytest.mark.parametrize('path', ["internal_link"])
 def test_external_link(obsidian):
     """Able to use normal markdown links which renders properly"""


### PR DESCRIPTION
## Summary
- support `.pdf` files when scanning for assets
- render PDF embeds as `<iframe>` blocks
- document PDF iframe support
- test PDF embedding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844524cd1688331b7a3faea0f199ee9