### PR TITLE
Update default PDF iframe attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Files are similar:
 ![[photo.jpg | custom alt text]]
 ```
 
-PDF files referenced using image syntax will be embedded via an `<iframe>`.
+PDF files referenced using image syntax will be embedded via an `<iframe>`
+with `width="100%"`, `height="800px"`, and `style="border: none;"`.
 
 They explain more about the syntax in the section on [how to embed files](https://help.obsidian.md/How+to/Embed+files)
 

--- a/pelican/plugins/obsidian/obsidian.py
+++ b/pelican/plugins/obsidian/obsidian.py
@@ -75,8 +75,12 @@ class ObsidianMarkdownReader(YAMLMetadataReader):
             path = FILE_PATHS.get(filename)
             if path:
                 if filename.lower().endswith('.pdf'):
-                    link_structure = '<iframe src="{{static}}{path}{filename}"></iframe>'.format(
-                        path=path, filename=filename
+                    link_structure = (
+                        '<iframe src="{{static}}{path}{filename}" width="100%" '
+                        'height="800px" style="border: none;"></iframe>'.format(
+                            path=path,
+                            filename=filename,
+                        )
                     )
                 else:
                     link_structure = '![{linkname}]({{static}}{path}{filename})'.format(

--- a/pelican/plugins/tests/test_obsidian_plugin.py
+++ b/pelican/plugins/tests/test_obsidian_plugin.py
@@ -95,7 +95,10 @@ def test_internal_image_in_article(obsidian):
 def test_internal_pdf_in_article(obsidian):
     """PDFs embedded with image syntax are rendered using iframes"""
     content, meta = obsidian
-    assert '<iframe src="{static}/assets/docs/sample.pdf"></iframe>' == content
+    assert (
+        '<iframe src="{static}/assets/docs/sample.pdf" width="100%" '
+        'height="800px" style="border: none;"></iframe>'
+    ) == content
 
 
 @pytest.mark.parametrize('path', ["internal_link"])


### PR DESCRIPTION
## Summary
- embed PDF files in articles using a full-width 800px iframe with no border
- document the iframe default attributes in the README
- adjust tests for new PDF iframe output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684462767dcc833190bc20af08e54676