### PR TITLE
Add PDF iframe fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Files are similar:
 
 PDF files referenced using image syntax will be embedded via an `<iframe>`
 with `width="100%"`, `height="800px"`, and `style="border: none;"`.
+A fallback download link is included for browsers that cannot render the PDF.
 
 They explain more about the syntax in the section on [how to embed files](https://help.obsidian.md/How+to/Embed+files)
 

--- a/pelican/plugins/obsidian/obsidian.py
+++ b/pelican/plugins/obsidian/obsidian.py
@@ -77,7 +77,10 @@ class ObsidianMarkdownReader(YAMLMetadataReader):
                 if filename.lower().endswith('.pdf'):
                     link_structure = (
                         '<iframe src="{{static}}{path}{filename}" width="100%" '
-                        'height="800px" style="border: none;"></iframe>'.format(
+                        'height="800px" style="border: none;"></iframe>'
+                        '<p><!-- browser fall back --> Click here to download. '
+                        '<a href="{{static}}{path}{filename}" target="_blank" '
+                        'rel="noopener">Download the PDF</a></p>'.format(
                             path=path,
                             filename=filename,
                         )

--- a/pelican/plugins/tests/test_obsidian_plugin.py
+++ b/pelican/plugins/tests/test_obsidian_plugin.py
@@ -97,7 +97,10 @@ def test_internal_pdf_in_article(obsidian):
     content, meta = obsidian
     assert (
         '<iframe src="{static}/assets/docs/sample.pdf" width="100%" '
-        'height="800px" style="border: none;"></iframe>'
+        'height="800px" style="border: none;"></iframe>\n'
+        '<p><!-- browser fall back --> Click here to download. '
+        '<a href="{static}/assets/docs/sample.pdf" target="_blank" '
+        'rel="noopener">Download the PDF</a></p>'
     ) == content
 
 


### PR DESCRIPTION
## Summary
- add fallback download link for embedded PDFs
- test new PDF iframe output
- document PDF fallback in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a2d0f2988331b007ed79063539f2